### PR TITLE
🐳 feat(docker-compose): add app-network for services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - app-network
 
   app:
     build:
@@ -28,6 +30,8 @@ services:
         condition: service_healthy
     ports:
       - "8080:8080"
+    networks:
+      - app-network
 
   nginx:
     image: nginx:latest
@@ -39,6 +43,12 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - app
+    networks:
+      - app-network
 
 volumes:
   db_data:
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
Adds a new network called `app-network` and connects the `app`, `db`, and
`nginx` services to it. This allows the services to communicate with each
other over the network, improving the overall architecture and
maintainability of the application.