### PR TITLE
✨ feat(database): add utf8mb4 support for database

### DIFF
--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -1,0 +1,5 @@
+FROM mysql:8.0
+
+COPY my.cnf /etc/mysql/conf.d/my.cnf
+
+RUN chmod 644 /etc/mysql/conf.d/my.cnf

--- a/database.go
+++ b/database.go
@@ -39,7 +39,7 @@ type QueryConfig struct {
 //   - (*Database, nil) on successful connection
 //   - (nil, error) if connection fails after 10 attempts
 func NewDatabase() (*Database, error) {
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 		os.Getenv("MYSQL_USER"),
 		os.Getenv("MYSQL_PASSWORD"),
 		os.Getenv("MYSQL_HOST"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   db:
-    image: mysql:8.0
+    build:
+      context: .
+      dockerfile: Dockerfile.mysql
     container_name: mysql-container
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}

--- a/init.sql
+++ b/init.sql
@@ -1,17 +1,19 @@
-CREATE DATABASE IF NOT EXISTS truth_or_dare_db;
+CREATE DATABASE IF NOT EXISTS truth_or_dare_db
+CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;
 
 USE truth_or_dare_db;
 
 CREATE TABLE IF NOT EXISTS questions (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    language VARCHAR(50) NOT NULL,
+    language VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
     type ENUM('truth', 'dare') NOT NULL,
-    task TEXT NOT NULL
+    task TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS tags (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL UNIQUE
+    name VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS question_tags (

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func getQuestions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if err := json.NewEncoder(w).Encode(questions); err != nil {
 		log.Printf("Failed to encode questions to JSON: %v", err)
 		http.Error(w, "Failed to encode questions to JSON", http.StatusInternalServerError)

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,9 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4


### PR DESCRIPTION
Adds support for utf8mb4 character set and collation to the database schema and connection string.
This ensures that the database can properly handle and store non-ASCII characters, such as emojis
and other special characters.
🐳 feat(docker): configure MySQL container with custom config

This commit introduces a custom MySQL configuration file and updates the
Docker Compose setup to build the MySQL container from a Dockerfile.

The key changes are:

- Add a `Dockerfile.mysql` to build the MySQL container with a custom
  configuration file
- Update the `docker-compose.yml` to use the new Dockerfile for the
  MySQL service
- Add a `my.cnf` file to configure the MySQL server to use UTF-8 as the
  default character set and collation

These changes ensure that the MySQL container is set up with the
appropriate character encoding settings, which is important for
supporting non-ASCII characters in the application.