### PR TITLE
✨ feat: Add GitHub Actions workflow to generate Go documentation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,34 @@
+name: Generate Go Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.23.4
+
+    - name: Install godoc
+      run: go install golang.org/x/tools/cmd/godoc@latest
+
+    - name: Generate documentation
+      run: godoc -html ./ > docs/index.html
+
+    - name: Commit and push documentation
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git add docs/
+        git commit -m "Update Go documentation [skip ci]" || echo "No changes to commit"
+        git push


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow that generates the Go documentation
for the project and commits the resulting HTML file to the `docs/` directory.
The workflow is triggered on pushes to the `main` branch and on manual workflow
dispatch. The generated documentation is committed with the `[skip ci]` tag to
avoid triggering the workflow again.