### PR TITLE
✨ feat: Improve documentation generation process

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -26,7 +26,10 @@ jobs:
       run: mkdir -p docs
 
     - name: Generate documentation
-      run: godoc -html ./ > docs/index.html
+      run: |
+        nohup godoc -http=:6060 &
+        sleep 5
+        wget -r -np -nH --cut-dirs=1 -P docs/ http://localhost:6060
 
     - name: Commit and push documentation
       run: |


### PR DESCRIPTION
Replaces the `godoc -html ./` command with a more robust approach:
- Starts the `godoc` server in the background on port 6060
- Waits for 5 seconds to ensure the server is running
- Uses `wget` to recursively download the generated documentation from
  the local `godoc` server and save it to the `docs/` directory

This change ensures that the documentation is generated correctly and
includes all necessary assets (CSS, images, etc.) for a better user
experience.