### PR TITLE
✨ feat: Update Go documentation generation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -19,22 +19,19 @@ jobs:
       with:
         go-version: 1.23.4
 
-    - name: Install godoc
-      run: go install golang.org/x/tools/cmd/godoc@latest
+    - name: Install gomarkdoc
+      run: go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
 
-    - name: Create docs directory
-      run: mkdir -p docs
+    - name: Create doc directory
+      run: mkdir -p doc
 
     - name: Generate documentation
-      run: |
-        nohup godoc -http=:6060 &
-        sleep 5
-        wget -r -np -nH --cut-dirs=1 -P docs/ http://localhost:6060
+      run: gomarkdoc -dir . -o doc
 
     - name: Commit and push documentation
       run: |
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git add docs/
+        git add README.md
         git commit -m "Update Go documentation [skip ci]" || echo "No changes to commit"
         git push


### PR DESCRIPTION
Replaces the use of `godoc` with `gomarkdoc` to generate the Go
documentation. This change simplifies the documentation generation
process by using a dedicated tool for Markdown-based documentation
instead of relying on the built-in `godoc` server.

The key changes are:

- Install `gomarkdoc` instead of `godoc`
- Create a `doc` directory instead of `docs`
- Use `gomarkdoc` to generate the documentation directly to the `doc`
  directory
- Commit and push the updated `README.md` file instead of the entire
  `docs` directory