### PR TITLE
✨ feat(api): Add GET /api/tags endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,9 +95,39 @@ func getQuestions(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getTags handles GET requests to /api/tags endpoint.
+//
+// Example:
+//
+//	Get /api/tags
+//
+// With curl:
+//
+//	curl -X GET "http://localhost:<port>/api/tags"
+//
+// Response:
+//
+//	200 OK: JSON array of tag names
+//	500 Internal Server Error: If database query fails
+func getTags(w http.ResponseWriter, r *http.Request) {
+	tags, err := db.GetTags()
+	if err != nil {
+		log.Printf("Failed to fetch tags: %v", err)
+		http.Error(w, "Failed to fetch tags", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if err := json.NewEncoder(w).Encode(tags); err != nil {
+		log.Printf("Failed to encode tags to JSON: %v", err)
+		http.Error(w, "Failed to encode tags to JSON", http.StatusInternalServerError)
+	}
+}
+
 // main initializes and starts the HTTP server.
 // The server provides the following endpoints:
 //   - GET /api/questions: Retrieve questions with optional filters
+//   - GET /api/tags: Retrieve all available tags
 //
 // Required environment variables:
 //   - APP_PORT: Port number for the HTTP server
@@ -109,6 +139,14 @@ func main() {
 	http.HandleFunc("/api/questions", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			getQuestions(w, r)
+		} else {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	http.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getTags(w, r)
 		} else {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}


### PR DESCRIPTION
This change adds a new GET /api/tags endpoint to the API server. The
endpoint retrieves all available tags from the database and returns them
as a JSON array.

The new getTags function handles the GET request to the /api/tags
endpoint. It fetches the tags from the database, encodes them to JSON,
and writes the response to the HTTP writer.

Additionally, the main function is updated to handle the new /api/tags
endpoint by registering the getTags handler.

This feature allows clients to retrieve the list of all available tags,
which can be useful for various UI components or filtering functionality.