### PR TITLE
✨ feat(api): Add MySQL database support for questions and tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Package main provides a REST API server for managing truth or dare questions.
+// Package main provides a REST API server for managing truth or dare questions. The server uses a MySQL database to store questions and tags.
 //
 // @title Truth or Dare API
 // @version 1.0


### PR DESCRIPTION
The main.go file is updated to indicate that the REST API server now uses a MySQL
database to store truth or dare questions and tags. This change allows the
server to persist data and provide a more robust and scalable solution for
managing the questions and tags.